### PR TITLE
Fixing 'no matching constructor...' issue

### DIFF
--- a/experiments/yarn/src/main/scala/org/apache/gearpump/experiments/yarn/master/YarnApplicationMaster.scala
+++ b/experiments/yarn/src/main/scala/org/apache/gearpump/experiments/yarn/master/YarnApplicationMaster.scala
@@ -281,7 +281,7 @@ object YarnApplicationMaster extends App with ArgumentsParser {
       val amActorProps = Props(
         new YarnApplicationMaster(appConfig,
           yarnConfiguration,
-          Props(classOf[ResourceManagerClient], yarnConfiguration, appConfig),
+          ResourceManagerClient.props(yarnConfiguration, appConfig),
           (yarnConf, am) => {
             val nmClient = new NMClientAsyncImpl(new NodeManagerCallbackHandler(am))
             nmClient.init(yarnConf)


### PR DESCRIPTION
Hi Kam,
in YarnAppMaster object,  Props(classOf[ResourceManagerClient], yarnConfiguration, appConfig) were incorrectly constructed, two Option arguments were missing. This was causing exception "no matching constructor...". After fixing that issue I was able to submit complex dag job (currently tested only on local yarn cluster). 

ps. Along with that fix I did some "brave" modification to your code in ResourceManagerClient. I've used Props approach described here : http://doc.akka.io/docs/akka/snapshot/scala/actors.html#Recommended_Practices,
removed Option from two last arguments and moved the default DI functions implementations to companion object. Of course this is just a proposal.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kkasravi/gearpump/3)

<!-- Reviewable:end -->
